### PR TITLE
We should bail if the save code wasn't also a 200.

### DIFF
--- a/builder/orka/step_create_image.go
+++ b/builder/orka/step_create_image.go
@@ -146,9 +146,10 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 
 		if imageSaveResponse.StatusCode != 200 {
 			ui.Error(fmt.Errorf("%s [%s]", OrkaAPIResponseErrorMessage, imageSaveResponse.Status).Error())
-		} else {
-			ui.Say(fmt.Sprintf("Image saved [%s] [%s]", imageSaveResponse.Status, imageSaveResponseData.Message))
+			return multistep.ActionHalt
 		}
+
+		ui.Say(fmt.Sprintf("Image saved [%s] [%s]", imageSaveResponse.Status, imageSaveResponseData.Message))
 	}
 
 	return multistep.ActionContinue


### PR DESCRIPTION
When an image is saved by the API, if it returns a non-200 the halt action was not being called, so calling processes saw a successful exit code when it really wasn't.