### PR TITLE
Allow user to configure how many cores for vCPU

### DIFF
--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	OrkaPassword        string `mapstructure:"orka_password" required:"true"`
 	OrkaVMBuilderPrefix string `mapstructure:"orka_vm_builder_prefix"`
 	OrkaVMBuilderName   string `mapstructure:"orka_vm_builder_name"`
+	OrkaVMCPUCore       int    `mapstructure:"orka_vm_cpu_core"`
 
 	// Name of the VM Config to launch from
 	SourceImage string `mapstructure:"source_image" required:"true"`
@@ -117,6 +118,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		}
 		// log.Printf("No Destination Image Specified. Using default: %s", name)
 		c.ImageName = name
+	}
+
+	// If we didn't specify the number of cores, set it to the default of 3.
+	if c.OrkaVMCPUCore == 0 {
+		c.OrkaVMCPUCore = 3
 	}
 
 	if es := c.CommConfig.Prepare(nil); len(es) > 0 {

--- a/builder/orka/config.hcl2spec.go
+++ b/builder/orka/config.hcl2spec.go
@@ -61,6 +61,7 @@ type FlatConfig struct {
 	OrkaPassword              *string           `mapstructure:"orka_password" required:"true" cty:"orka_password"`
 	OrkaVMBuilderPrefix       *string           `mapstructure:"orka_vm_builder_prefix" cty:"orka_vm_builder_prefix"`
 	OrkaVMBuilderName         *string           `mapstructure:"orka_vm_builder_name" cty:"orka_vm_builder_name"`
+	OrkaVMCPUCore             *int              `mapstructure:"orka_vm_cpu_core" cty:"orka_vm_cpu_core"`
 	SourceImage               *string           `mapstructure:"source_image" required:"true" cty:"source_image"`
 	ImageName                 *string           `mapstructure:"image_name" required:"false" cty:"image_name"`
 	SimulateCreate            *bool             `mapstructure:"simulate_create" cty:"simulate_create"`
@@ -133,6 +134,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"orka_password":                &hcldec.AttrSpec{Name: "orka_password", Type: cty.String, Required: false},
 		"orka_vm_builder_prefix":       &hcldec.AttrSpec{Name: "orka_vm_builder_prefix", Type: cty.String, Required: false},
 		"orka_vm_builder_name":         &hcldec.AttrSpec{Name: "orka_vm_builder_name", Type: cty.String, Required: false},
+		"orka_vm_cpu_core":             &hcldec.AttrSpec{Name: "orka_vm_cpu_core", Type: cty.Number, Required: false},
 		"source_image":                 &hcldec.AttrSpec{Name: "source_image", Type: cty.String, Required: false},
 		"image_name":                   &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"simulate_create":              &hcldec.AttrSpec{Name: "simulate_create", Type: cty.Bool, Required: false},

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -148,8 +148,8 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 		OrkaVMName:  config.OrkaVMBuilderName,
 		OrkaVMImage: actualImage,
 		OrkaImage:   config.OrkaVMBuilderName,
-		OrkaCPUCore: 3,
-		VCPUCount:   3,
+		OrkaCPUCore: config.OrkaVMCPUCore,
+		VCPUCount:   config.OrkaVMCPUCore,
 	}
 	vmCreateConfigRequestDataJSON, _ := json.Marshal(vmCreateConfigRequestData)
 	vmCreateConfigRequest, err := http.NewRequest(

--- a/examples/macos-catalina.json
+++ b/examples/macos-catalina.json
@@ -24,7 +24,7 @@
       "orka_endpoint": "{{user `ORKA_ENDPOINT`}}",
       "orka_user": "{{user `ORKA_USER`}}",
       "orka_password": "{{user `ORKA_PASSWORD`}}",
-      "image_precopy": true,
+      "image_precopy": false,
       "simulate_create": false,
       "no_create_image": false,
       "no_delete_vm": false


### PR DESCRIPTION
Let's the user configure vCPU cores to pass along to the Orka API.